### PR TITLE
Fix mapOptions/issue30

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,35 @@
 export function addEvent(vue, target, name) {
   naver.maps.Event.addListener(target, name, event => vue.$emit(name, event));
 }
+
+export function mapSettings(mapOptions, initLayers){
+  const settings = {
+    center: new window.naver.maps.LatLng(mapOptions.lat, mapOptions.lng),
+    maxZoom: 21,
+    minZoom: 0,
+  }
+  const mapOptionsLat = mapOptions.lat || mapOptions.lat === 0 ? true : false;
+  const mapOptionsLng = mapOptions.lng || mapOptions.lng === 0 ? true : false;
+
+  if(!mapOptionsLat || !mapOptionsLng) delete settings.center;
+
+  if(!initLayers || initLayers.length === 0) return settings;
+  else return mapLayers(settings, initLayers);
+}
+
+export function mapLayers(settings, initLayers){
+  const layers = {
+    BACKGROUND: 'bg', BACKGROUND_DETAIL: 'ol', BICYCLE: 'br', CADASTRAL: 'lp', CTT: 'ctt', HIKING_TRAIL: 'ar', PANORAMA: 'pr',
+    POI_KOREAN: 'lko', TRANSIT: 'ts', KOREAN: 'lko', ENGLISH: 'len', CHINESE: 'lzh', JAPANESE: 'lja'
+  };
+
+  settings.mapTypes = new window.naver.maps.MapTypeRegistry({
+    'normal': window.naver.maps.NaverStyleMapTypeOption.getNormalMap(
+      {
+        overlayType: initLayers.map(layer => layers[layer]).join('.'),
+      }
+    )
+  });
+
+  return settings;
+}

--- a/src/Map.vue
+++ b/src/Map.vue
@@ -42,18 +42,7 @@
       initLayers: {
         deep: true,
         handler(newValue) {
-          const settings = {};
-          const layers = {
-            BACKGROUND: 'bg', BACKGROUND_DETAIL: 'ol', BICYCLE: 'br', CADASTRAL: 'lp', CTT: 'ctt', HIKING_TRAIL: 'ar', PANORAMA: 'pr',
-            POI_KOREAN: 'lko', TRANSIT: 'ts', KOREAN: 'lko', ENGLISH: 'len', CHINESE: 'lzh', JAPANESE: 'lja'
-          };
-          settings.mapTypes = new window.naver.maps.MapTypeRegistry({
-            'normal': window.naver.maps.NaverStyleMapTypeOption.getNormalMap(
-              {
-                overlayType: newValue.map(layer => layers[layer]).join('.'),
-              }
-            )
-          });
+          const settings = _.mapLayers({}, newValue)
           this.setOptions('mapTypes', settings.mapTypes);
         }
       }
@@ -305,22 +294,7 @@
        * @description load naver maps
        */
       loadNaverMapsComponents() {
-        const settings = {
-          center: new window.naver.maps.LatLng(this.mapOptions.lat, this.mapOptions.lng),
-          maxZoom: 21,
-          minZoom: 0,
-        };
-        const layers = {
-          BACKGROUND: 'bg', BACKGROUND_DETAIL: 'ol', BICYCLE: 'br', CADASTRAL: 'lp', CTT: 'ctt', HIKING_TRAIL: 'ar', PANORAMA: 'pr',
-          POI_KOREAN: 'lko', TRANSIT: 'ts', KOREAN: 'lko', ENGLISH: 'len', CHINESE: 'lzh', JAPANESE: 'lja'
-        };
-        settings.mapTypes = new window.naver.maps.MapTypeRegistry({
-          'normal': window.naver.maps.NaverStyleMapTypeOption.getNormalMap(
-            {
-              overlayType: this.initLayers.map(layer => layers[layer]).join('.'),
-            }
-          )
-        });
+        const settings = _.mapSettings(this.mapOptions, this.initLayers)
         this.map = new window.naver.maps.Map('vue-naver-maps', {...settings, ...this.mapOptions});
         if (this.zoomControlOptions && this.zoomControlOptions.position) this.setOptions({zoomControlOptions: {position: naver.maps.Position[this.zoomControlOptions.position]}});
         window.$naverMapsCallback.forEach(v => v(this.map));
@@ -338,10 +312,8 @@
       }
     },
     mounted() {
-      if (this.mapOptions.lat && this.mapOptions.lng) {
-        if (window.naver) this.loadNaverMapsComponents();
-        else document.getElementById('naver-map-load').onload = () => window.naver.maps.onJSContentLoaded = this.loadNaverMapsComponents;
-      } else throw new Error('mapOptions must be included lat and lng.');
+      if (window.naver) this.loadNaverMapsComponents();
+      else document.getElementById('naver-map-load').onload = () => window.naver.maps.onJSContentLoaded = this.loadNaverMapsComponents;
     },
     destroyed() {
       window.$naverMapsLoaded = false;


### PR DESCRIPTION
[#30 mapOption 에 lat, lng 값이 0 일 때 오류](https://github.com/Shin-JaeHeon/vue-naver-maps/issues/30)
### 문제
- lat, lng이 0일때 javascript falsy로 인해 error 처리
- initLayers를 props로 넘기지 않는 경우, 사용자 정의 레이어를 추가하는 과정에서 undefined.map로 인한 error

### 해결
- [네이버맵 API 가이드 기본지도 예제 ](https://navermaps.github.io/maps.js.ncp/docs/tutorial-1-map-simple.example.html) 에 나온것 처럼 기본 center 좌표가 서울 시청이여서, lat lng이 없는 경우 네이버 default center 좌표로 설정 되는 방향으로 잡아 봤습니다.
- layer는 props로 initLayer를 따로 선언하지 않으면 기본레이어, 사용자가 layer를 추가 하게 된다면 사용자정의레이어를 사용하는 방향으로 잡아 봤습니다.
