### PR TITLE
fix: api url 변경대응

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const vueNaverMaps = {
         window.$naverMapsCallback = [];
         window.$naverMapsLoaded = false;
         const apiType = options.useGovAPI ? 'gov' : 'ncp';
-        const URL = `https://openapi.map.naver.com/openapi/v3/maps.js?${apiType}ClientId=${options.clientID}${(options.subModules ? `&submodules=${options.subModules}` : '')}`;
+        const URL = `https://oapi.map.naver.com/openapi/v3/maps.js?${apiType}ClientId=${options.clientID}${(options.subModules ? `&submodules=${options.subModules}` : '')}`;
         const script = document.createElement('script');
         if (script) {
           script.setAttribute('src', URL);


### PR DESCRIPTION
- 네이버지도 URL 변경대응(기존 URL 23년말까지 사용가능)